### PR TITLE
Use pyit600 0.0.3 to be compatible with more thermostats

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,5 +4,5 @@
     "documentation": "https://github.com/konradb3/homeassistant_salus",
     "dependencies": [],
     "codeowners": ["konradb3"],
-    "requirements": ["git+https://github.com/konradb3/pyit600.git@fix_thermostats_detection#pyit600"]
+    "requirements": ["pyit600==0.0.3"]
   }


### PR DESCRIPTION
* Compatible with more thermostats
* Better error handling when no thermostats are found